### PR TITLE
Fix pipeline

### DIFF
--- a/.github/workflows/python_package.yaml
+++ b/.github/workflows/python_package.yaml
@@ -7,7 +7,6 @@ jobs:
     uses: AFMC-MAJCOM/ci_python/.github/workflows/version_check.yaml@main
   build:
     runs-on: ubuntu-latest
-    needs: check-version
     strategy:
       matrix:
         python-version: ["3.11"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "datawave_cli"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
     "requests",
     "kubernetes",


### PR DESCRIPTION
This is neede because it was found the `check-version` job doesn't run on the main branch. By having the build `need` the `check-version`, none of the pipeline would run on the main. This change makes it so `build` does not depend on `check-version` and runs in parallel to it.